### PR TITLE
[FEAT] [UNTESTED] support for loading fundamental data with multiple …

### DIFF
--- a/src/Backtester.py
+++ b/src/Backtester.py
@@ -1,31 +1,21 @@
-from typing import Union
-
 #import deprecation
 
-from FMP.fmp import Income_statement_entry, Balance_statement_entry, Cashflow_statement_entry, Financial_ratio_entry, \
-    Price_entry
-
-from Universe import Stock_Universe
 from Datahandler import DataHandler
+from FMP.fmp import Price_entry
 from Portfolio import Portfolio
-
-
-
+from Universe import Stock_Universe
 
 
 class Backtester:
-    def __init__(self, universe:Stock_Universe, start_date: str, end_date: str, initial_cash: int,
-                 data_requirements: list[Union[Income_statement_entry
-                 , Balance_statement_entry, Cashflow_statement_entry
-                 , Financial_ratio_entry, Price_entry]], strategy):
-
+    def __init__(self, universe: Stock_Universe, start_date: str, end_date: str, initial_cash: int, strategy):
+        self.strategy = strategy()
         self.data_handler = DataHandler(universe
-                                        , start_date, end_date, data_requirements)
+                                        , start_date, end_date, strategy)
         self.data_handler.loaddata()
+        self.strategy.add_data_handler(self.data_handler)
         self.universe = universe
         self.benchmark = universe.get_universe("benchmark")
         self.portfolio = Portfolio(initial_cash, universe, self.benchmark)
-        self.strategy = strategy(self.data_handler, universe)  # Strategy(self.data_handler, universe)
 
     def run_backtest(self):
         while not self.data_handler.is_data_end():

--- a/src/Strategy.py
+++ b/src/Strategy.py
@@ -1,3 +1,7 @@
+from dataclasses import dataclass
+
+from FMP.fmp import *
+
 
 def rebalance(rebalance_period):
     def decorator(func):
@@ -18,11 +22,31 @@ def rebalance(rebalance_period):
         return wrapper
 
     return decorator
-class Strategy:
 
-    def __init__(self, data_handler, universe):
+
+@dataclass
+class Strategy_dependence:
+    dependence_name: Union[
+        Price_entry, Financial_ratio_entry, Balance_statement_entry, Cashflow_statement_entry, Income_statement_entry]
+    period: Datapoint_period
+    num_of_data_needed: int
+
+    def __init__(self, dependence_name, period, num_of_data_needed):
+        self.dependence_name = dependence_name
+        self.period = period
+        self.num_of_data_needed = num_of_data_needed
+
+
+class Strategy:
+    inherent_dependencies = [Strategy_dependence(Price_entry.open, 'd', 1),
+                             Strategy_dependence(Price_entry.adjClose, 'd', 1),
+                             Strategy_dependence(Price_entry.close, 'd', 1)]
+
+    def __init__(self):
+        self.data_handler = None
+
+    def add_data_handler(self, data_handler):
         self.data_handler = data_handler
-        self.universe = universe
 
     def generate_signals(self):
         pass

--- a/src/Universe.py
+++ b/src/Universe.py
@@ -1,45 +1,48 @@
 from FMP.fmp import *
 
+
 class Stock_Universe:
     def __init__(self):
-        self.__requirement = {'default_group':[]}
-        self.__groups ={"default_group": None}
+        self.__requirement = {'default_group': []}
+        self.__groups = {"default_group": None}
         self.__total_universe = set()
 
     def add_holdings_to_group(self, ticker, type, topN=1, group_name='default_group'):
         if group_name in self.__requirement.keys():
-            self.__requirement[group_name].append((ticker,type,topN))
+            self.__requirement[group_name].append((ticker, type, topN))
         else:
             self.__requirement[group_name] = []
             self.__requirement[group_name].append((ticker, type, topN))
 
-    def add_benchmark(self,ticker):
+    def add_benchmark(self, ticker):
         self.add_holdings_to_group(ticker, type="stock", group_name="benchmark")
 
-    def load_data(self,start_date, end_date):
+    def load_data(self, start_date, end_date):
         for name, assets_info in self.__requirement.items():
             dfs = []
             individual_stocks = []
             for asset in assets_info:
-               ticker , asset_type, topN = asset
-               if asset_type == "index":
-                   df = fmp_get_etf_holdings(ticker, apikey=API_KEY
-                                        , start_date=start_date, end_date=end_date, highest_N=topN)
-                   dfs.append(df)
-               else:
-                   individual_stocks.append(ticker)
+                ticker, asset_type, topN = asset
+                if asset_type == "index":
+                    df = fmp_get_etf_holdings(ticker, apikey=API_KEY
+                                              , start_date=(
+                                datetime.datetime.strptime(start_date, "%Y-%m-%d") - datetime.timedelta(
+                            1)).strftime("%Y-%m-%d"), end_date=end_date, highest_N=topN)
+                    dfs.append(df)
+                else:
+                    individual_stocks.append(ticker)
             if dfs == []:
-                merged=pd.DataFrame(index=[pd.to_datetime(start_date)])
+                merged = pd.DataFrame(index=[pd.to_datetime(start_date)])
                 row_num = 1
             else:
-                merged = pd.concat(dfs,axis=1).ffill().apply(lambda s: s.fillna({i: [] for i in df.index}))
+                merged = pd.concat(dfs, axis=1).ffill().apply(lambda s: s.fillna({i: [] for i in df.index}))
                 row_num = len(merged)
             merged["const"] = [individual_stocks for _ in range(row_num)]
-            self.__groups[name]= pd.DataFrame(merged.apply(lambda row: sum(row, []), axis=1),columns=['holdings'])
+            self.__groups[name] = pd.DataFrame(merged.apply(lambda row: sum(row, []), axis=1), columns=['holdings'])
             self.__total_universe = self.__total_universe.union(set(self.__groups[name].sum().values[0]))
         return 0
 
-    def get_universe(self,name):
+    def get_universe(self, name):
         """
         get the holding data of a group.
         should only be called by the data_handler

--- a/user_strategies/MOM_STRATEGY.py
+++ b/user_strategies/MOM_STRATEGY.py
@@ -1,19 +1,21 @@
-from FMP.fmp import *
-from FMP.main import stock_database
-from Universe import Stock_Universe
-import pandas as pd
 import numpy as np
+import pandas as pd
 from Strategy import Strategy, rebalance
-class MOM_STRATEGY(Strategy):
-    def __init__(self, data_handler, universe):
 
-        super().__init__(data_handler, universe)
+from FMP.fmp import *
+
+
+class MOM_STRATEGY(Strategy):
+    inherent_dependencies = Strategy.inherent_dependencies
+
+    def __init__(self):
+
+        super().__init__()
 
     @rebalance(20)
     def generate_signals(self):
         def z_score(df):
             return (df - df.mean()) / df.std()
-
         def calc_mom_score(series_A):
             # Step 1: Create Series B based on the rules given for Series A
             series_B = series_A  # series_A.clip(lower=-3, upper=3)
@@ -58,7 +60,7 @@ class MOM_STRATEGY(Strategy):
         d_ret = close_prices.diff().dropna()
         comp_mom_z = sharpe_mom(close_prices,d_ret,abs_filter=False)
         # comp_mom = mom12
-        uni = self.universe
+        uni = self.data_handler.get_dynamic_universe()
         mom_score = calc_mom_score(comp_mom_z[uni])
         ranked_securities = list(mom_score.rank(ascending=True).sort_values(ascending=False).index)
 

--- a/user_strategies/SIMPLE_FUNDAMANTAL_STRATEGY.py
+++ b/user_strategies/SIMPLE_FUNDAMANTAL_STRATEGY.py
@@ -1,14 +1,20 @@
-from FMP.fmp import Price_entry, Income_statement_entry, Balance_statement_entry, Financial_ratio_entry
-from Universe import Stock_Universe
-import pandas as pd
 import numpy as np
-from Strategy import Strategy, rebalance
+import pandas as pd
 from Backtester import Backtester
+from Strategy import Strategy, rebalance, Strategy_dependence
+from Universe import Stock_Universe
+
+from FMP.fmp import Income_statement_entry, Balance_statement_entry, Datapoint_period
 
 
 class Simple_Fundamental_Stratery(Strategy):
-    def __init__(self, data_handler, universe):
-        super().__init__(data_handler, universe)
+    inherent_dependencies = Strategy.inherent_dependencies + [
+        Strategy_dependence(Income_statement_entry.gross_profit, Datapoint_period.annual, 1),
+        Strategy_dependence(Balance_statement_entry.total_equity, Datapoint_period.annual, 1)
+    ]
+
+    def __init__(self):
+        super().__init__()
 
     @rebalance(60)
     def generate_signals(self):
@@ -34,7 +40,7 @@ class Simple_Fundamental_Stratery(Strategy):
         uni = list(set(GP.iloc[0].index).intersection(set(equity.iloc[0].index)).intersection(set(uni)))
         GPOE_z = z_score((GP / equity)[uni].iloc[0]).clip(lower=-3, upper=3)
         ranked_securities = list(GPOE_z.rank(ascending=True).sort_values(ascending=False).index)
-        N = len(ranked_securities) // 5
+        N = int(len(ranked_securities) / 5 + 1)
         w = equal_weights(N, N)
         signals = {}
         for s, w1 in zip(ranked_securities[0:N], w):
@@ -43,69 +49,70 @@ class Simple_Fundamental_Stratery(Strategy):
         return signals
 
 
-class PM_ratio(Strategy):
-    def __init__(self, data_handler, universe):
-        super().__init__(data_handler, universe)
-
-    @rebalance(60)
-    def generate_signals(self):
-        def z_score(df: pd.Series):
-            return (df - df.mean()) / df.std()
-
-        def equal_weights(N, M):
-            weights = np.array([1 for i in range(N)])
-            # Normalize the weights so they sum to 1
-            normalized_weights = weights / np.sum(weights)
-            return normalized_weights
-
-        def calc_score(series_A):
-            # Step 1: Create Series B based on the rules given for Series A
-            series_B = series_A.clip(lower=-3, upper=3)
-
-            # Step 2: Apply the transformation rules for Series B
-            def update_value(Z):
-                if Z > 0:
-                    return 1 + Z
-                elif Z < 0:
-                    return 1 / (1 - Z)
-                else:
-                    return Z  # If Z == 0, it remains 0
-
-            series_B_transformed = series_B.apply(update_value)
-
-            return series_B_transformed
-
-        def z_score(df):
-            return (df - df.mean()) / df.std()
-
-        LEV = self.data_handler.get_fundamentals(metric=Financial_ratio_entry.equity_multiplier, prev=1)
-        D = self.data_handler.get_fundamentals(metric=Balance_statement_entry.total_debt, prev=1)
-        I = self.data_handler.get_fundamentals(metric=Income_statement_entry.interest_expense, prev=1)
-        GP = self.data_handler.get_fundamentals(metric=Income_statement_entry.gross_profit, prev=1)
-        Asset = self.data_handler.get_fundamentals(metric=Balance_statement_entry.total_assets, prev=1)
-        if LEV is None or D is None or I is None:
-            return None
-        I.dropna(axis=1, how="all", inplace=True)
-        D.dropna(axis=1, how="all", inplace=True)
-        LEV.dropna(axis=1, how="all", inplace=True)
-        GP.dropna(axis=1, how="all", inplace=True)
-        Asset.dropna(axis=1, how="all", inplace=True)
-        uni = self.data_handler.get_dynamic_universe()
-        uni = list(set((LEV).iloc[0].index).intersection(set((I).iloc[0].index)).intersection(
-            set((D).iloc[0].index)).intersection(set(uni)))
-        LEV = LEV[uni].iloc[0]
-        Interest_rate_inv = (D / I)[uni].iloc[0]
-        GPOA = GP[uni].iloc[0] / Asset[uni].iloc[0]
-        comp_factor = calc_score(GPOA.rank(ascending=True) + (LEV * Interest_rate_inv).rank(ascending=True))
-        ranked_securities = list(comp_factor.rank(ascending=True).sort_values(ascending=False).index)
-        N = int(len(ranked_securities) / 5 + 1)
-        # w = equal_weights(N,N)
-        w = comp_factor[ranked_securities[0:N]] / comp_factor[ranked_securities[0:N]].sum()
-        signals = {}
-        for s, w1 in zip(ranked_securities[0:N], w):
-            signals[s] = w1
-
-        return signals
+# class PM_ratio(Strategy):
+#     inherent_dependencies = Strategy.inherent_dependencies
+#     def __init__(self):
+#         super().__init__()
+#
+#     @rebalance(60)
+#     def generate_signals(self):
+#         def z_score(df: pd.Series):
+#             return (df - df.mean()) / df.std()
+#
+#         def equal_weights(N, M):
+#             weights = np.array([1 for i in range(N)])
+#             # Normalize the weights so they sum to 1
+#             normalized_weights = weights / np.sum(weights)
+#             return normalized_weights
+#
+#         def calc_score(series_A):
+#             # Step 1: Create Series B based on the rules given for Series A
+#             series_B = series_A.clip(lower=-3, upper=3)
+#
+#             # Step 2: Apply the transformation rules for Series B
+#             def update_value(Z):
+#                 if Z > 0:
+#                     return 1 + Z
+#                 elif Z < 0:
+#                     return 1 / (1 - Z)
+#                 else:
+#                     return Z  # If Z == 0, it remains 0
+#
+#             series_B_transformed = series_B.apply(update_value)
+#
+#             return series_B_transformed
+#
+#         def z_score(df):
+#             return (df - df.mean()) / df.std()
+#
+#         LEV = self.data_handler.get_fundamentals(metric=Financial_ratio_entry.equity_multiplier, prev=1)
+#         D = self.data_handler.get_fundamentals(metric=Balance_statement_entry.total_debt, prev=1)
+#         I = self.data_handler.get_fundamentals(metric=Income_statement_entry.interest_expense, prev=1)
+#         GP = self.data_handler.get_fundamentals(metric=Income_statement_entry.gross_profit, prev=1)
+#         Asset = self.data_handler.get_fundamentals(metric=Balance_statement_entry.total_assets, prev=1)
+#         if LEV is None or D is None or I is None:
+#             return None
+#         I.dropna(axis=1, how="all", inplace=True)
+#         D.dropna(axis=1, how="all", inplace=True)
+#         LEV.dropna(axis=1, how="all", inplace=True)
+#         GP.dropna(axis=1, how="all", inplace=True)
+#         Asset.dropna(axis=1, how="all", inplace=True)
+#         uni = self.data_handler.get_dynamic_universe()
+#         uni = list(set((LEV).iloc[0].index).intersection(set((I).iloc[0].index)).intersection(
+#             set((D).iloc[0].index)).intersection(set(uni)))
+#         LEV = LEV[uni].iloc[0]
+#         Interest_rate_inv = (D / I)[uni].iloc[0]
+#         GPOA = GP[uni].iloc[0] / Asset[uni].iloc[0]
+#         comp_factor = calc_score(GPOA.rank(ascending=True) + (LEV * Interest_rate_inv).rank(ascending=True))
+#         ranked_securities = list(comp_factor.rank(ascending=True).sort_values(ascending=False).index)
+#         N = int(len(ranked_securities) / 5 + 1)
+#         # w = equal_weights(N,N)
+#         w = comp_factor[ranked_securities[0:N]] / comp_factor[ranked_securities[0:N]].sum()
+#         signals = {}
+#         for s, w1 in zip(ranked_securities[0:N], w):
+#             signals[s] = w1
+#
+#         return signals
 
 
 if __name__ == "__main__":
@@ -121,13 +128,11 @@ if __name__ == "__main__":
     #                         , strategy= MOM_STRATEGY
     #                         , benchmark="QQQ")
     uni = Stock_Universe()
-    uni.add_holdings_to_group("DGRW", "index", topN=30)
+    uni.add_holdings_to_group("DGRW", "index", topN=2)
     # uni.add_holdings_to_group("XMHQ", "index", topN= 10)
     uni.add_benchmark("SPY")
     backtester = Backtester(uni
                             , start_date, end_date, initial_cash
-                            , [Price_entry.adjClose, Price_entry.open, Price_entry.close
-                                , Income_statement_entry.gross_profit, Balance_statement_entry.total_equity]
                             , strategy=Simple_Fundamental_Stratery)
     backtester.run_backtest()
     backtester.portfolio.position_history.set_index("Date").to_csv("TEST.holdings.csv")


### PR DESCRIPTION
…periods.

+ Able to specify data requirement in Strategy level. (no need to add at the backtest level)
+ Reduce the waste of price data. Able to retrieve fundamental data before simulation start date
+ [BUG FIX] extend universe retrieve time range. extended to 1 day before simulation starts
+ Remove unnecessary func args
+ [BUG FIX] Work around for Enum type change issue. (Reason unknown)